### PR TITLE
Replace another sysret with sysretq

### DIFF
--- a/kernel/syscalls/sys_execve.c
+++ b/kernel/syscalls/sys_execve.c
@@ -141,7 +141,7 @@ int sys_execve(const char *path, char *const argv[], char *const envp[]) {
     "xor r15, r15;"
     "xor rbp, rbp;"
     ".byte 0x48;"
-    "sysret"
+    "sysretq"
     :: [entry]"r"(p.entry + p.load_addr), [rsp]"r"(p.rsp)
     : "r11", "rcx"
   );


### PR DESCRIPTION
After this change. It can be built on fedora38.